### PR TITLE
Fix datetime parsing exception in WeatherForecast

### DIFF
--- a/GhostUI/Models/WeatherForecast.cs
+++ b/GhostUI/Models/WeatherForecast.cs
@@ -10,6 +10,6 @@ namespace GhostUI.Models
 
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
-        public int Id => Convert.ToInt32(DateFormatted?.Replace("/", ""));
+        public int Id => Random.Shared.Next(0, 1000);
     }
 }


### PR DESCRIPTION
When datetime delimiter is `-` instead of `/` the endpoint was crashing with FormatException.